### PR TITLE
[#19] convert mail subject to utf8

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -6,6 +6,7 @@
 #
 Rails.configuration.to_prepare do
   IncomingMessage.class_eval do
+    # TODO: Remove after upgrade to 0.31.0.0+
     def parse_raw_email!(force = nil)
       # The following fields may be absent; we treat them as cached
       # values in case we want to regenerate them (due to mail
@@ -17,7 +18,7 @@ Rails.configuration.to_prepare do
         ActiveRecord::Base.transaction do
           self.extract_attachments!
           write_attribute(:sent_at, self.mail.date || self.created_at)
-          write_attribute(:subject, self.mail.subject)
+          write_attribute(:subject, convert_string_to_utf8(mail.subject).string)
           write_attribute(:mail_from, MailHandler.get_from_name(self.mail))
           if self.from_email
             self.mail_from_domain = PublicBody.extract_domain_from_email(self.from_email)

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,4 +5,31 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
+  IncomingMessage.class_eval do
+    def parse_raw_email!(force = nil)
+      # The following fields may be absent; we treat them as cached
+      # values in case we want to regenerate them (due to mail
+      # parsing bugs, etc).
+      if self.raw_email.nil?
+        raise "Incoming message id=#{id} has no raw_email"
+      end
+      if (!force.nil? || self.last_parsed.nil?)
+        ActiveRecord::Base.transaction do
+          self.extract_attachments!
+          write_attribute(:sent_at, self.mail.date || self.created_at)
+          write_attribute(:subject, self.mail.subject)
+          write_attribute(:mail_from, MailHandler.get_from_name(self.mail))
+          if self.from_email
+            self.mail_from_domain = PublicBody.extract_domain_from_email(self.from_email)
+          else
+            self.mail_from_domain = ""
+          end
+          write_attribute(:valid_to_reply_to, self._calculate_valid_to_reply_to)
+          self.last_parsed = Time.now
+          self.foi_attachments reload=true
+          self.save!
+        end
+      end
+    end
+  end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,11 +5,4 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
-    OutgoingMessage.class_eval do
-        # Add intro paragraph to new request template
-        def default_letter
-            return nil if self.message_type == 'followup'
-            #"If you uncomment this line, this text will appear as default text in every message"    
-        end
-    end        
 end


### PR DESCRIPTION
Fix handling of non-utf8 in mail subject

Backports the significant part of the core fix [1] until we upgrade this
install.

Fixes https://github.com/mysociety/colombia-theme/issues/19

[1] https://github.com/mysociety/alaveteli/commit/58f77d8c63fe4c602c851fcbc42544acdbba4f59
